### PR TITLE
1.13.6.2 alpine filter health check path

### DIFF
--- a/lua-init.conf
+++ b/lua-init.conf
@@ -29,9 +29,13 @@ init_by_lua_block {
   else
     print("File "..filePath.." doesn\'t exist")
   end
+
+  healthCheckPath = os.getenv(HEALT_CHECK_PATH)
 }
 
 log_by_lua_block {
-  metric_requests:inc(1, {ngx.var.host, ngx.var.status})
-  metric_latency:observe(ngx.now() - ngx.req.start_time(), {ngx.var.host})
+  if ngx.var.request_uri ~= healthCheckPath then
+    metric_requests:inc(1, {ngx.var.host, ngx.var.status})
+    metric_latency:observe(ngx.now() - ngx.req.start_time(), {ngx.var.host})
+  end
 }

--- a/lua-init.conf
+++ b/lua-init.conf
@@ -12,7 +12,12 @@ init_by_lua_block {
     "nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
   metric_latency = prometheus:histogram(
     "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
-
+  metric_bytes = prometheus:counter(
+    "nginx_http_request_size_bytes", "Total size of incoming requests")
+  metric_response_sizes = prometheus:counter(
+    "nginx_http_response_size_bytes", "Total size of outgoing reponses")
+  metric_connections = prometheus:gauge(
+    "nginx_http_connections", "Number of HTTP connections", {"state"})
 
   -- Load HTTP2 Push list
   local filePath = "/usr/share/nginx/www/http2-push-map.txt"
@@ -35,7 +40,10 @@ init_by_lua_block {
 
 log_by_lua_block {
   if ngx.var.request_uri ~= healthCheckPath then
-    metric_requests:inc(1, {ngx.var.host, ngx.var.status})
-    metric_latency:observe(ngx.now() - ngx.req.start_time(), {ngx.var.host})
+    local host = ngx.var.host
+    metric_requests:inc(1, {host, ngx.var.status})
+    metric_latency:observe(ngx.now() - ngx.req.start_time(), {host})
+    metric_bytes:inc(tonumber(ngx.var.request_length))
+    metric_response_sizes:inc(tonumber(ngx.var.bytes_sent))
   end
 }

--- a/lua-init.conf
+++ b/lua-init.conf
@@ -30,7 +30,7 @@ init_by_lua_block {
     print("File "..filePath.." doesn\'t exist")
   end
 
-  healthCheckPath = os.getenv(HEALT_CHECK_PATH)
+  healthCheckPath = os.getenv("HEALT_CHECK_PATH")
 }
 
 log_by_lua_block {


### PR DESCRIPTION
Since we started sending readiness checks through the normal request port - it's required by GCE ingress, which we use for IAP - our graphs are skewed by the large volume of readiness checks; this PR filters it out in this particular sidecar; I'll do a similar one for https://github.com/Travix-International/docker-openresty