### PR TITLE
update PROXY_HOST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,7 +250,7 @@ COPY ssl/ssl.key /etc/ssl/private/ssl.key
 ENV OFFLOAD_TO_HOST=localhost \
     OFFLOAD_TO_PORT=80 \
     OFFLOAD_TO_PROTO=http \
-    PROXY_HOST='$host' \
+    PROXY_HOST='host' \
     HEALT_CHECK_PATH=/ \
     ALLOW_CIDRS="allow all;" \
     SERVICE_NAME="myservice" \

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,6 +22,10 @@ http {
   default_type application/octet-stream;
   server_names_hash_bucket_size 128;
 
+  map $${PROXY_HOST} $proxy_host {
+    default $${PROXY_HOST};
+  }
+
   # logs
   log_format  main escape=json '{ "timestamp": "$time_iso8601",'
                     ' "type": "nginx.access",'
@@ -36,6 +40,7 @@ http {
                     ' "http_referer": "$http_referer",'
                     ' "http_user_agent": "$http_user_agent",'
                     ' "http_cf_ray": "$http_cf_ray",'
+                    ' "proxy_host": "$proxy_host",'
                     ' "http_x_forwarded_for": "$http_x_forwarded_for"}';
 
   access_log /dev/stdout main;
@@ -106,7 +111,7 @@ http {
   deny all;
 
   # set proxy defaults
-  proxy_set_header Host ${PROXY_HOST};
+  proxy_set_header Host $proxy_host;
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header X-Forwarded-Host $host;
@@ -164,7 +169,7 @@ http {
       proxy_pass ${OFFLOAD_TO_PROTO}://backend;
 
       # headers that get redefined if not specified here
-      proxy_set_header Host ${PROXY_HOST};
+      proxy_set_header Host $proxy_host;
       proxy_set_header Connection $connection_upgrade;
 
       #cors
@@ -183,7 +188,7 @@ http {
       proxy_pass ${OFFLOAD_TO_PROTO}://backend;
 
       # headers that get redefined if not specified here
-      proxy_set_header Host ${PROXY_HOST};
+      proxy_set_header Host $proxy_host;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
 
@@ -210,7 +215,7 @@ http {
       proxy_pass ${OFFLOAD_TO_PROTO}://backend;
 
       # headers that get redefined if not specified here
-      proxy_set_header Host ${PROXY_HOST};
+      proxy_set_header Host $proxy_host;
       proxy_set_header Connection $connection_upgrade;
 
       #cors
@@ -229,7 +234,7 @@ http {
       proxy_pass ${OFFLOAD_TO_PROTO}://backend;
 
       # headers that get redefined if not specified here
-      proxy_set_header Host ${PROXY_HOST};
+      proxy_set_header Host $proxy_host;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
 
@@ -249,7 +254,7 @@ http {
       proxy_pass ${OFFLOAD_TO_PROTO}://backend${HEALT_CHECK_PATH};
 
       # headers that get redefined if not specified here
-      proxy_set_header Host ${PROXY_HOST};
+      proxy_set_header Host $proxy_host;
       proxy_set_header Connection $connection_upgrade;
     }
   }


### PR DESCRIPTION
Updated default value for PROXY_HOST to not requiring $ in it as Estafette changes `$var` into `${var}` and use nginx var instead of using environment variable directly to be able to log it.
